### PR TITLE
Add `yo` as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,16 @@
 		"test": "mocha --reporter spec"
 	},
 	"engines": {
-		"node": ">=0.8.0"
+		"node": ">=0.8.0",
+		"npm": ">=1.2.10"
 	},
 	"dependencies": {
 		"yeoman-generator": "~0.10.2"
 	},
 	"devDependencies": {
 		"mocha": "~1.9.0"
+	},
+	"peerDependencies": {
+		"yo": ">=1.0.0-rc.1.1"
 	}
 }


### PR DESCRIPTION
By adding `yo` as peer dependency, the user only has to `npm install -g generator-firefox-os` and is good to go.

I also added `npm >= 1.2.10` as engine requirement which shows a non-fatal warning in case the user is using an earlier version of npm, which doesn't support peer dependencies yet.

/ref https://github.com/yeoman/generator/issues/305
