### PR TITLE
Remove sudo from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Getting Started
 
-1. Install: `[sudo] npm install -g generator-firefox-os`
+1. Install: `npm install -g generator-firefox-os`
 3. Run: `yo firefox-os`
 4. Start writing your Firefox OS app :)
 


### PR DESCRIPTION
We now block any attempt to use sudo in `yo`, so it's moot.
