### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,7 @@
 		"name": "Zeno Rocha",
 		"email": "zno.rocha@gmail.com"
 	},
-	"license": [
-		{
-			"type": "MIT",
-			"url": "http://zenorocha.mit-license.org/"
-		}
-	],
+	"license": "MIT",
 	"scripts": {
 		"test": "mocha --reporter spec"
 	},


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)
